### PR TITLE
Fixed README.md root directory issue

### DIFF
--- a/Blip/setup.py
+++ b/Blip/setup.py
@@ -1,10 +1,13 @@
 import setuptools
+import os
+
+pwd = os.path.join(os.getcwd(),"README.md")
 
 setuptools.setup(
     name="django-blip",
     version="0.0.10",
     description="Python package to intercept all external api call during django test.",
-    long_description=open("README.md").read(),
+    long_description=open(pwd).read(),
     long_description_content_type="text/markdown",
     author="Abhinav Prakash",
     author_email="abhinavsp0730@gmail.com",


### PR DESCRIPTION
I have used `os.getcwd()` to get the current directory, and `os.path.join` to concatentate the `README.md` with the rest of the directory. I hope this works for you.

Closes Issue #4 