### PR TITLE
Open README from project root, and properly close file

### DIFF
--- a/Blip/setup.py
+++ b/Blip/setup.py
@@ -1,10 +1,15 @@
+import os.path
 import setuptools
+
+path = os.path.join(__file__, "../README.md")
+with open(path, "r") as f:
+	readme = f.read()
 
 setuptools.setup(
     name="django-blip",
     version="0.0.10",
     description="Python package to intercept all external api call during django test.",
-    long_description=open("README.md").read(),
+    long_description=readme,
     long_description_content_type="text/markdown",
     author="Abhinav Prakash",
     author_email="abhinavsp0730@gmail.com",


### PR DESCRIPTION
open("README").read() fails to actually close the file after reading.
Additionally we can use __file__ to always grab the README from the
project root regardless of where the setup file is called from.
