### PR TITLE
Feat: Setup github actions to release django-blip package to PyPi

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,91 @@
+name: Publish release to PyPI
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    env:
+      working_directory: ./Blip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install pypa/build
+        run: python3 -m pip install build --user
+
+      - name: Handle package version on setup file
+        run: |
+          sed -i "s#PACKAGE_VERSION#${GITHUB_REF#refs/*/}#" ./Blip/setup.py
+
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+        working-directory: ${{ env.working_directory }}
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: ${{ env.working_directory }}/dist/
+
+  publish-to-pypi:
+    name: Publish package to PyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-blip
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.10
+
+  github-release:
+    name: Sign package with Sigstore and upload it to GitHub Release
+    needs:
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v2.1.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Upload to GitHub Release using the `gh` CLI.
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        run: gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'

--- a/Blip/setup.py
+++ b/Blip/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="django-blip",
-    version="0.0.10",
+    version="PACKAGE_VERSION",
     description="Python package to intercept all external api call during django test.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
In state, it does not build correctly due to error in `setup.py` to open `README.md` #4 

I decide to use easy way to handle release version dynamically. 
Let me know if you prefer an other way @abhinavsp0730 ;-)

I had not tested to publish to pypi, but only on test.pypi. You can see action runs [here](https://github.com/yalefresne/blip/actions/runs/6539178401)